### PR TITLE
refactor: extract run data access into query services

### DIFF
--- a/app/Ai/Tools/FetchHeartRateDataTool.php
+++ b/app/Ai/Tools/FetchHeartRateDataTool.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Ai\Tools;
 
-use App\Models\HeartRateSample;
-use App\Models\Run;
+use App\Queries\HeartRateQuery;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
@@ -24,33 +23,7 @@ class FetchHeartRateDataTool implements Tool
     {
         $days = $request['days'] ?? 30;
 
-        $runs = Run::query()
-            ->where('user_id', $this->userId)
-            ->where('start_time', '>=', now()->subDays($days))
-            ->whereNotNull('avg_heart_rate')
-            ->with(['heartRateSamples' => fn ($q) => $q->orderBy('timestamp')])
-            ->orderByDesc('start_time')
-            ->get();
-
-        $maxHr = HeartRateSample::query()
-            ->whereIn('run_id', $runs->pluck('id'))
-            ->max('bpm') ?? 190;
-
-        $runData = $runs->map(fn (Run $run) => [
-            'id' => $run->id,
-            'date' => $run->start_time->toDateString(),
-            'avg_heart_rate' => $run->avg_heart_rate,
-            'duration_seconds' => $run->duration_seconds,
-            'distance_km' => (float) $run->distance_km,
-            'sample_count' => $run->heartRateSamples->count(),
-            'min_bpm' => $run->heartRateSamples->min('bpm'),
-            'max_bpm' => $run->heartRateSamples->max('bpm'),
-        ]);
-
-        return json_encode([
-            'max_observed_hr' => $maxHr,
-            'runs' => $runData,
-        ]);
+        return json_encode((new HeartRateQuery($this->userId))->forPeriod($days));
     }
 
     public function schema(JsonSchema $schema): array

--- a/app/Ai/Tools/FetchRecentRunsTool.php
+++ b/app/Ai/Tools/FetchRecentRunsTool.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Ai\Tools;
 
-use App\Models\Run;
+use App\Queries\RunsQuery;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
@@ -23,13 +23,7 @@ class FetchRecentRunsTool implements Tool
     {
         $days = $request['days'] ?? 30;
 
-        $runs = Run::query()
-            ->where('user_id', $this->userId)
-            ->where('start_time', '>=', now()->subDays($days))
-            ->orderByDesc('start_time')
-            ->get(['id', 'start_time', 'distance_km', 'duration_seconds', 'steps', 'avg_heart_rate', 'avg_pace_seconds_per_km']);
-
-        return $runs->toJson();
+        return (new RunsQuery($this->userId))->recent($days)->toJson();
     }
 
     public function schema(JsonSchema $schema): array

--- a/app/Ai/Tools/FetchRunStatsTool.php
+++ b/app/Ai/Tools/FetchRunStatsTool.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Ai\Tools;
 
-use App\Models\Run;
+use App\Queries\RunStatsQuery;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Ai\Contracts\Tool;
 use Laravel\Ai\Tools\Request;
@@ -23,21 +23,7 @@ class FetchRunStatsTool implements Tool
     {
         $days = $request['days'] ?? 90;
 
-        $query = Run::query()
-            ->where('user_id', $this->userId)
-            ->where('start_time', '>=', now()->subDays($days));
-
-        $stats = [
-            'period_days' => $days,
-            'total_distance_km' => (float) $query->sum('distance_km'),
-            'total_time_seconds' => (int) $query->sum('duration_seconds'),
-            'run_count' => $query->count(),
-            'avg_pace_seconds_per_km' => (int) $query->avg('avg_pace_seconds_per_km'),
-            'best_pace_seconds_per_km' => (int) $query->min('avg_pace_seconds_per_km'),
-            'longest_run_km' => (float) $query->max('distance_km'),
-        ];
-
-        return json_encode($stats);
+        return json_encode((new RunStatsQuery($this->userId))->forPeriod($days));
     }
 
     public function schema(JsonSchema $schema): array

--- a/app/Queries/HeartRateQuery.php
+++ b/app/Queries/HeartRateQuery.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Models\HeartRateSample;
+use App\Models\Run;
+
+class HeartRateQuery
+{
+    public function __construct(private int $userId) {}
+
+    /**
+     * @return array{max_observed_hr: int, runs: array<int, array{id: int, date: string, avg_heart_rate: int|null, duration_seconds: int, distance_km: float, sample_count: int, min_bpm: int|null, max_bpm: int|null}>}
+     */
+    public function forPeriod(int $days = 30): array
+    {
+        $runs = Run::query()
+            ->where('user_id', $this->userId)
+            ->where('start_time', '>=', now()->subDays($days))
+            ->whereNotNull('avg_heart_rate')
+            ->with(['heartRateSamples' => fn ($q) => $q->orderBy('timestamp')])
+            ->orderByDesc('start_time')
+            ->get();
+
+        $maxHr = HeartRateSample::query()
+            ->whereIn('run_id', $runs->pluck('id'))
+            ->max('bpm') ?? 190;
+
+        $runData = $runs->map(fn (Run $run) => [
+            'id' => $run->id,
+            'date' => $run->start_time->toDateString(),
+            'avg_heart_rate' => $run->avg_heart_rate,
+            'duration_seconds' => $run->duration_seconds,
+            'distance_km' => (float) $run->distance_km,
+            'sample_count' => $run->heartRateSamples->count(),
+            'min_bpm' => $run->heartRateSamples->min('bpm'),
+            'max_bpm' => $run->heartRateSamples->max('bpm'),
+        ])->all();
+
+        return [
+            'max_observed_hr' => (int) $maxHr,
+            'runs' => $runData,
+        ];
+    }
+}

--- a/app/Queries/RunStatsQuery.php
+++ b/app/Queries/RunStatsQuery.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Models\Run;
+
+class RunStatsQuery
+{
+    public function __construct(private int $userId) {}
+
+    /**
+     * @return array{period_days: int, total_distance_km: float, total_time_seconds: int, run_count: int, avg_pace_seconds_per_km: int, best_pace_seconds_per_km: int, longest_run_km: float}
+     */
+    public function forPeriod(int $days = 90): array
+    {
+        $query = Run::query()
+            ->where('user_id', $this->userId)
+            ->where('start_time', '>=', now()->subDays($days));
+
+        return [
+            'period_days' => $days,
+            'total_distance_km' => (float) $query->sum('distance_km'),
+            'total_time_seconds' => (int) $query->sum('duration_seconds'),
+            'run_count' => $query->count(),
+            'avg_pace_seconds_per_km' => (int) $query->avg('avg_pace_seconds_per_km'),
+            'best_pace_seconds_per_km' => (int) $query->min('avg_pace_seconds_per_km'),
+            'longest_run_km' => (float) $query->max('distance_km'),
+        ];
+    }
+}

--- a/app/Queries/RunsQuery.php
+++ b/app/Queries/RunsQuery.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries;
+
+use App\Models\Run;
+use Illuminate\Database\Eloquent\Collection;
+
+class RunsQuery
+{
+    public function __construct(private int $userId) {}
+
+    /**
+     * @return Collection<int, Run>
+     */
+    public function recent(int $days = 30): Collection
+    {
+        return Run::query()
+            ->where('user_id', $this->userId)
+            ->where('start_time', '>=', now()->subDays($days))
+            ->orderByDesc('start_time')
+            ->get(['id', 'start_time', 'distance_km', 'duration_seconds', 'steps', 'avg_heart_rate', 'avg_pace_seconds_per_km']);
+    }
+}

--- a/tests/Feature/Queries/HeartRateQueryTest.php
+++ b/tests/Feature/Queries/HeartRateQueryTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\HeartRateSample;
+use App\Models\Run;
+use App\Models\User;
+use App\Queries\HeartRateQuery;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+test('only returns runs belonging to the given user', function () {
+    $otherUser = User::factory()->create();
+    Run::factory()->for($this->user)->create([
+        'start_time' => now()->subDays(5),
+        'avg_heart_rate' => 150,
+    ]);
+    Run::factory()->for($otherUser)->create([
+        'start_time' => now()->subDays(5),
+        'avg_heart_rate' => 150,
+    ]);
+
+    $result = (new HeartRateQuery($this->user->id))->forPeriod(30);
+
+    expect($result['runs'])->toHaveCount(1);
+});
+
+test('only returns runs within the date window', function () {
+    Run::factory()->for($this->user)->create([
+        'start_time' => now()->subDays(5),
+        'avg_heart_rate' => 150,
+    ]);
+    Run::factory()->for($this->user)->create([
+        'start_time' => now()->subDays(45),
+        'avg_heart_rate' => 150,
+    ]);
+
+    $result = (new HeartRateQuery($this->user->id))->forPeriod(30);
+
+    expect($result['runs'])->toHaveCount(1);
+});
+
+test('skips runs with null avg_heart_rate', function () {
+    Run::factory()->for($this->user)->create([
+        'start_time' => now()->subDays(5),
+        'avg_heart_rate' => 150,
+    ]);
+    Run::factory()->for($this->user)->create([
+        'start_time' => now()->subDays(6),
+        'avg_heart_rate' => null,
+    ]);
+
+    $result = (new HeartRateQuery($this->user->id))->forPeriod(30);
+
+    expect($result['runs'])->toHaveCount(1);
+});
+
+test('max_observed_hr falls back to 190 when no samples exist', function () {
+    Run::factory()->for($this->user)->create([
+        'start_time' => now()->subDays(5),
+        'avg_heart_rate' => 150,
+    ]);
+
+    $result = (new HeartRateQuery($this->user->id))->forPeriod(30);
+
+    expect($result['max_observed_hr'])->toBe(190);
+});
+
+test('returns per-run shape with eager-loaded sample aggregates', function () {
+    $run = Run::factory()->for($this->user)->create([
+        'start_time' => now()->subDays(5),
+        'avg_heart_rate' => 150,
+        'duration_seconds' => 1800,
+        'distance_km' => 5.0,
+    ]);
+    HeartRateSample::factory()->for($run)->create(['bpm' => 120]);
+    HeartRateSample::factory()->for($run)->create(['bpm' => 175]);
+    HeartRateSample::factory()->for($run)->create(['bpm' => 200]);
+
+    $result = (new HeartRateQuery($this->user->id))->forPeriod(30);
+
+    expect($result['max_observed_hr'])->toBe(200);
+    expect($result['runs'])->toHaveCount(1);
+
+    $entry = $result['runs'][0];
+    expect(array_keys($entry))->toEqualCanonicalizing([
+        'id', 'date', 'avg_heart_rate', 'duration_seconds', 'distance_km', 'sample_count', 'min_bpm', 'max_bpm',
+    ]);
+    expect($entry['id'])->toBe($run->id);
+    expect($entry['sample_count'])->toBe(3);
+    expect($entry['min_bpm'])->toBe(120);
+    expect($entry['max_bpm'])->toBe(200);
+});

--- a/tests/Feature/Queries/RunStatsQueryTest.php
+++ b/tests/Feature/Queries/RunStatsQueryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Run;
+use App\Models\User;
+use App\Queries\RunStatsQuery;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+test('only aggregates runs belonging to the given user', function () {
+    $otherUser = User::factory()->create();
+
+    Run::factory()->for($this->user)->create([
+        'start_time' => now()->subDays(10),
+        'distance_km' => 5.0,
+        'duration_seconds' => 1800,
+        'avg_pace_seconds_per_km' => 360,
+    ]);
+    Run::factory()->for($otherUser)->create([
+        'start_time' => now()->subDays(10),
+        'distance_km' => 999.0,
+        'duration_seconds' => 9999,
+        'avg_pace_seconds_per_km' => 100,
+    ]);
+
+    $stats = (new RunStatsQuery($this->user->id))->forPeriod(90);
+
+    expect($stats['run_count'])->toBe(1);
+    expect($stats['total_distance_km'])->toBe(5.0);
+});
+
+test('only aggregates runs within the date window', function () {
+    Run::factory()->for($this->user)->create([
+        'start_time' => now()->subDays(10),
+        'distance_km' => 5.0,
+    ]);
+    Run::factory()->for($this->user)->create([
+        'start_time' => now()->subDays(120),
+        'distance_km' => 50.0,
+    ]);
+
+    $stats = (new RunStatsQuery($this->user->id))->forPeriod(90);
+
+    expect($stats['run_count'])->toBe(1);
+    expect($stats['total_distance_km'])->toBe(5.0);
+});
+
+test('returns the documented array shape', function () {
+    Run::factory()->for($this->user)->create([
+        'start_time' => now()->subDays(5),
+        'distance_km' => 10.0,
+        'duration_seconds' => 3000,
+        'avg_pace_seconds_per_km' => 300,
+    ]);
+    Run::factory()->for($this->user)->create([
+        'start_time' => now()->subDays(20),
+        'distance_km' => 4.0,
+        'duration_seconds' => 1600,
+        'avg_pace_seconds_per_km' => 400,
+    ]);
+
+    $stats = (new RunStatsQuery($this->user->id))->forPeriod(90);
+
+    expect(array_keys($stats))->toEqualCanonicalizing([
+        'period_days',
+        'total_distance_km',
+        'total_time_seconds',
+        'run_count',
+        'avg_pace_seconds_per_km',
+        'best_pace_seconds_per_km',
+        'longest_run_km',
+    ]);
+    expect($stats['period_days'])->toBe(90);
+    expect($stats['total_distance_km'])->toBe(14.0);
+    expect($stats['total_time_seconds'])->toBe(4600);
+    expect($stats['run_count'])->toBe(2);
+    expect($stats['best_pace_seconds_per_km'])->toBe(300);
+    expect($stats['longest_run_km'])->toBe(10.0);
+});

--- a/tests/Feature/Queries/RunsQueryTest.php
+++ b/tests/Feature/Queries/RunsQueryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Run;
+use App\Models\User;
+use App\Queries\RunsQuery;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+test('only returns runs belonging to the given user', function () {
+    $otherUser = User::factory()->create();
+    $mine = Run::factory()->for($this->user)->create(['start_time' => now()->subDays(5)]);
+    Run::factory()->for($otherUser)->create(['start_time' => now()->subDays(5)]);
+
+    $runs = (new RunsQuery($this->user->id))->recent(30);
+
+    expect($runs)->toHaveCount(1);
+    expect($runs->first()->id)->toBe($mine->id);
+});
+
+test('only returns runs within the date window', function () {
+    Run::factory()->for($this->user)->create(['start_time' => now()->subDays(5)]);
+    Run::factory()->for($this->user)->create(['start_time' => now()->subDays(45)]);
+
+    $runs = (new RunsQuery($this->user->id))->recent(30);
+
+    expect($runs)->toHaveCount(1);
+});
+
+test('returns the expected columns ordered by start_time desc', function () {
+    $older = Run::factory()->for($this->user)->create(['start_time' => now()->subDays(10)]);
+    $newer = Run::factory()->for($this->user)->create(['start_time' => now()->subDays(2)]);
+
+    $runs = (new RunsQuery($this->user->id))->recent(30);
+
+    expect($runs->first()->id)->toBe($newer->id);
+    expect($runs->last()->id)->toBe($older->id);
+
+    $first = $runs->first()->getAttributes();
+    expect(array_keys($first))->toEqualCanonicalizing([
+        'id', 'start_time', 'distance_km', 'duration_seconds', 'steps', 'avg_heart_rate', 'avg_pace_seconds_per_km',
+    ]);
+});


### PR DESCRIPTION
Closes #22.

## Summary
- New `App\Queries\` namespace with `RunsQuery`, `RunStatsQuery`, `HeartRateQuery`. All Eloquent logic for fetching run data lives here.
- `FetchRecentRunsTool`, `FetchRunStatsTool`, `FetchHeartRateDataTool` are now thin wrappers that delegate to the query services and JSON-encode the result. Tool `description()`, `schema()`, and default day windows are unchanged.
- Pure refactor — agent behavior is identical. This unblocks the AI chat refactor and the MCP server (#14), which will reuse the same query services behind different tool contracts.

## Test plan
- [x] `tests/Feature/Analysis/RunSkillTest.php` still passes unchanged (10 tests, 20 assertions) — acceptance criterion from #22.
- [x] New `tests/Feature/Queries/{Runs,RunStats,HeartRate}QueryTest.php` covering user scoping, date window, return shape, plus HR-specific null-avg-HR exclusion and the `190` fallback (11 tests, 28 assertions).
- [x] Full suite: 100 passed (496 assertions).
- [x] `vendor/bin/pint --dirty --format agent` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)