### PR TITLE
feat: add RunCoachAgent and streaming chat endpoint

### DIFF
--- a/app/Ai/Agents/RunCoachAgent.php
+++ b/app/Ai/Agents/RunCoachAgent.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ai\Agents;
+
+use App\Ai\Tools\ComparePeriodsTool;
+use App\Ai\Tools\FetchHeartRateDataTool;
+use App\Ai\Tools\FetchPersonalBestsTool;
+use App\Ai\Tools\FetchRunDetailTool;
+use App\Ai\Tools\FetchRunStatsTool;
+use App\Ai\Tools\FetchRunsTool;
+use Laravel\Ai\Attributes\Provider;
+use Laravel\Ai\Attributes\UseCheapestModel;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Conversational;
+use Laravel\Ai\Contracts\HasTools;
+use Laravel\Ai\Enums\Lab;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+#[Provider(Lab::Anthropic)]
+#[UseCheapestModel]
+class RunCoachAgent implements Agent, Conversational, HasTools
+{
+    use Promptable;
+
+    /**
+     * @param  iterable<\Laravel\Ai\Messages\Message>  $messages
+     */
+    public function __construct(
+        private int $userId,
+        private iterable $messages = [],
+    ) {}
+
+    public function instructions(): Stringable|string
+    {
+        return <<<'PROMPT'
+You are a personal running coach with direct access to the athlete's training data through tools. Always reach for a tool before making a quantitative claim — never invent distances, paces, heart rates, or dates.
+
+Tools available:
+- fetch_runs: list runs in a window with optional distance / pace / heart-rate filters
+- fetch_run_stats: aggregated totals and averages over a window
+- fetch_heart_rate_data: heart-rate detail and time-in-zone estimates
+- fetch_run_detail: a single run including HR samples and pace splits
+- compare_periods: side-by-side aggregates for two date ranges
+- fetch_personal_bests: PBs at 1K / 5K / 10K / HM / M
+
+Citation rule: whenever a tool result includes a `url` field for a specific run, link that run in your reply using markdown like `[YYYY-MM-DD — 8.2 km](url)`. Cite every specific run you reference. If a claim isn't backed by a tool result, say so plainly instead of guessing.
+
+Keep responses conversational and direct — short paragraphs, no headings unless the user asks for them. Offer concrete observations and one actionable suggestion when relevant.
+PROMPT;
+    }
+
+    public function tools(): iterable
+    {
+        return [
+            new FetchRunsTool($this->userId),
+            new FetchRunStatsTool($this->userId),
+            new FetchHeartRateDataTool($this->userId),
+            new FetchRunDetailTool($this->userId),
+            new ComparePeriodsTool($this->userId),
+            new FetchPersonalBestsTool($this->userId),
+        ];
+    }
+
+    public function messages(): iterable
+    {
+        return $this->messages;
+    }
+}

--- a/app/Http/Controllers/Analysis/ChatController.php
+++ b/app/Http/Controllers/Analysis/ChatController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Analysis;
+
+use App\Ai\Agents\RunCoachAgent;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Laravel\Ai\Messages\AssistantMessage;
+use Laravel\Ai\Messages\UserMessage;
+use Symfony\Component\HttpFoundation\Response;
+
+class ChatController
+{
+    public function stream(Request $request): Response|JsonResponse
+    {
+        $validated = $request->validate([
+            'messages' => 'required|array|min:1',
+            'messages.*.role' => 'required|string|in:user,assistant',
+            'messages.*.content' => 'required|string',
+        ]);
+
+        $messages = $validated['messages'];
+        $latest = array_pop($messages);
+
+        if ($latest['role'] !== 'user') {
+            return response()->json([
+                'message' => 'The most recent message must be from the user.',
+                'errors' => ['messages' => ['The most recent message must be from the user.']],
+            ], 422);
+        }
+
+        $history = array_map(
+            static fn (array $message) => $message['role'] === 'user'
+                ? new UserMessage($message['content'])
+                : new AssistantMessage($message['content']),
+            $messages,
+        );
+
+        $agent = new RunCoachAgent($request->user()->id, $history);
+
+        return $agent->stream($latest['content'])->toResponse($request);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Analysis\ChatController as AnalysisChatController;
 use App\Http\Controllers\Analysis\IndexController as AnalysisIndexController;
 use App\Http\Controllers\Analysis\RunSkillController;
 use App\Http\Controllers\Runs\DestroyController as RunsDestroyController;
@@ -21,6 +22,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::delete('runs/{run}', RunsDestroyController::class)->name('runs.destroy');
 
     Route::get('analysis', AnalysisIndexController::class)->name('analysis.index');
+    Route::post('analysis/chat', [AnalysisChatController::class, 'stream'])->name('analysis.chat');
     Route::post('analysis/{skill}', RunSkillController::class)->name('analysis.run');
 });
 

--- a/tests/Feature/Analysis/ChatTest.php
+++ b/tests/Feature/Analysis/ChatTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Ai\Agents\RunCoachAgent;
+use App\Ai\Tools\ComparePeriodsTool;
+use App\Ai\Tools\FetchHeartRateDataTool;
+use App\Ai\Tools\FetchPersonalBestsTool;
+use App\Ai\Tools\FetchRunDetailTool;
+use App\Ai\Tools\FetchRunStatsTool;
+use App\Ai\Tools\FetchRunsTool;
+use App\Models\Run;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+function streamedText(string $body): string
+{
+    $text = '';
+
+    foreach (explode("\n\n", $body) as $line) {
+        if (! str_starts_with($line, 'data: ') || $line === 'data: [DONE]') {
+            continue;
+        }
+
+        $payload = json_decode(substr($line, 6), true);
+
+        if (is_array($payload) && ($payload['type'] ?? null) === 'text_delta') {
+            $text .= $payload['delta'] ?? '';
+        }
+    }
+
+    return $text;
+}
+
+test('unauthenticated user cannot reach the chat stream', function () {
+    $this->postJson('/analysis/chat', [
+        'messages' => [['role' => 'user', 'content' => 'Hi']],
+    ])->assertUnauthorized();
+});
+
+test('stream returns SSE envelope with data lines and trailing DONE marker', function () {
+    Run::factory()->for($this->user)->count(3)->create();
+
+    RunCoachAgent::fake(['Your last three runs look strong.']);
+
+    $response = $this->actingAs($this->user)
+        ->postJson('/analysis/chat', [
+            'messages' => [
+                ['role' => 'user', 'content' => 'How am I doing?'],
+            ],
+        ]);
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toContain('text/event-stream');
+
+    $body = $response->streamedContent();
+
+    expect($body)->toContain('data: ');
+    expect($body)->toEndWith("data: [DONE]\n\n");
+});
+
+test('streamed body relays citation links produced by the model', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    $citation = '[2026-05-20 — 8.2 km]('.route('runs.show', $run->id).')';
+
+    RunCoachAgent::fake(["Great work on {$citation}!"]);
+
+    $body = $this->actingAs($this->user)
+        ->postJson('/analysis/chat', [
+            'messages' => [
+                ['role' => 'user', 'content' => 'Tell me about my last run.'],
+            ],
+        ])
+        ->streamedContent();
+
+    expect(streamedText($body))->toContain($citation);
+});
+
+test('user with zero runs still gets a streamed response', function () {
+    RunCoachAgent::fake(['Add a run to unlock deeper analysis.']);
+
+    $response = $this->actingAs($this->user)
+        ->postJson('/analysis/chat', [
+            'messages' => [
+                ['role' => 'user', 'content' => 'What do you see?'],
+            ],
+        ]);
+
+    $response->assertOk();
+    expect(streamedText($response->streamedContent()))->toBe('Add a run to unlock deeper analysis.');
+});
+
+test('prior assistant turns are passed as conversation history', function () {
+    Run::factory()->for($this->user)->count(3)->create();
+
+    RunCoachAgent::fake(['Sure, here is a follow-up.']);
+
+    $response = $this->actingAs($this->user)
+        ->postJson('/analysis/chat', [
+            'messages' => [
+                ['role' => 'user', 'content' => 'How am I doing?'],
+                ['role' => 'assistant', 'content' => 'You ran 30 km last week.'],
+                ['role' => 'user', 'content' => 'And the week before?'],
+            ],
+        ]);
+
+    $response->assertOk();
+    expect(streamedText($response->streamedContent()))->toContain('follow-up');
+});
+
+test('empty messages array fails validation', function () {
+    $this->actingAs($this->user)
+        ->postJson('/analysis/chat', ['messages' => []])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['messages']);
+});
+
+test('last message must be from the user', function () {
+    $this->actingAs($this->user)
+        ->postJson('/analysis/chat', [
+            'messages' => [
+                ['role' => 'user', 'content' => 'Hi'],
+                ['role' => 'assistant', 'content' => 'Hello'],
+            ],
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['messages']);
+});
+
+test('agent wires up all six read tools so tool calls can stream as separate events', function () {
+    $tools = collect((new RunCoachAgent(1))->tools())->map(fn ($tool) => $tool::class)->all();
+
+    expect($tools)->toEqualCanonicalizing([
+        FetchRunsTool::class,
+        FetchRunStatsTool::class,
+        FetchHeartRateDataTool::class,
+        FetchRunDetailTool::class,
+        ComparePeriodsTool::class,
+        FetchPersonalBestsTool::class,
+    ]);
+});
+
+test('system prompt instructs the model to cite runs by url', function () {
+    $instructions = (string) (new RunCoachAgent(1))->instructions();
+
+    expect($instructions)->toContain('url')
+        ->and($instructions)->toContain('Citation');
+});


### PR DESCRIPTION
## Summary

- Adds `App\Ai\Agents\RunCoachAgent` — a single chat agent (`Agent` + `HasTools` + `Conversational`, no structured output) that wires all six existing read tools and instructs the model to cite runs by linking the `url` field returned by `FetchRunsTool`, `FetchRunDetailTool`, and `FetchPersonalBestsTool`.
- Adds `App\Http\Controllers\Analysis\ChatController@stream` and `POST /analysis/chat` (web group, auth + verified). The controller validates a `messages[]` payload, maps prior turns into `UserMessage`/`AssistantMessage`, and returns the agent's `StreamableAgentResponse` (SSE `data: ...\n\n` ending with `[DONE]`). History is client-managed — no server persistence yet.
- 9 feature tests covering the SSE envelope, citation pass-through, multi-turn history, validation, auth, the zero-run path, and the tool/system-prompt wiring. Existing `/analysis/{skill}` endpoint and its tests are untouched.

Closes #24. UI, write tools, and removal of the six fixed-skill agents are intentionally out of scope (separate issues).

### Caveat on the "tool-call events" acceptance criterion
`FakeTextGateway::streamText()` only yields text events, so the suite cannot synthesize a `ToolCall` event through `RunCoachAgent::fake()`. The test `agent wires up all six read tools so tool calls can stream as separate events` covers the upstream half — a real provider invocation will surface `tool_call` events on the same SSE channel (the laravel/ai `ToolCall` event class already serializes to `{"type":"tool_call",...}`).

## Test plan

- [x] `php artisan test --compact --filter=ChatTest` — 9 passing
- [x] `php artisan test --compact --filter=RunSkillTest` — 10 passing (no regression)
- [x] `vendor/bin/pint --dirty --format agent` — clean
- [ ] Manual `curl` (logged-in session) against `POST /analysis/chat` once merged — observe streamed `tool_call` then `text_delta` events for a real prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)