### PR TITLE
feat: add confirm-card flow for run edit/delete via chat (#26)

### DIFF
--- a/app/Ai/Agents/RunCoachAgent.php
+++ b/app/Ai/Agents/RunCoachAgent.php
@@ -10,6 +10,8 @@ use App\Ai\Tools\FetchPersonalBestsTool;
 use App\Ai\Tools\FetchRunDetailTool;
 use App\Ai\Tools\FetchRunStatsTool;
 use App\Ai\Tools\FetchRunsTool;
+use App\Ai\Tools\ProposeRunDeleteTool;
+use App\Ai\Tools\ProposeRunEditTool;
 use Laravel\Ai\Attributes\Provider;
 use Laravel\Ai\Attributes\UseSmartestModel;
 use Laravel\Ai\Contracts\Agent;
@@ -38,7 +40,7 @@ class RunCoachAgent implements Agent, Conversational, HasTools
         return <<<'PROMPT'
 You are a personal running coach with direct access to the athlete's training data through tools. Always reach for a tool before making a quantitative claim — never invent distances, paces, heart rates, or dates.
 
-Tools available:
+Read tools (use freely):
 - fetch_runs: list runs in a window with optional distance / pace / heart-rate filters
 - fetch_run_stats: aggregated totals and averages over a window
 - fetch_heart_rate_data: heart-rate detail and time-in-zone estimates
@@ -46,7 +48,13 @@ Tools available:
 - compare_periods: side-by-side aggregates for two date ranges
 - fetch_personal_bests: PBs at 1K / 5K / 10K / HM / M
 
+Write tools (require user confirmation):
+- propose_run_edit: propose changes to a single run; the UI renders a confirm card
+- propose_run_delete: propose deleting a single run; the UI renders a confirm card
+
 Citation rule: whenever a tool result includes a `url` field for a specific run, link that run in your reply using markdown like `[YYYY-MM-DD — 8.2 km](url)`. Cite every specific run you reference. If a claim isn't backed by a tool result, say so plainly instead of guessing.
+
+Confirmation rule: tools whose names start with `propose_` NEVER mutate data. After calling one, the UI automatically renders a confirm card with Confirm / Cancel buttons. Your text reply must be a single brief sentence describing the proposed action (e.g. "I'd like to delete Tuesday's 8.2 km run — confirm below?") and MUST NOT include any JSON, the pending_action envelope, or the UUID. Do not promise the change is complete; the user still has to click Confirm. If the user asks to undo a mutation you just proposed, instruct them to click Cancel on the card instead of calling another tool.
 
 Keep responses conversational and direct — short paragraphs, no headings unless the user asks for them. Offer concrete observations and one actionable suggestion when relevant.
 PROMPT;
@@ -61,6 +69,8 @@ PROMPT;
             new FetchRunDetailTool($this->userId),
             new ComparePeriodsTool($this->userId),
             new FetchPersonalBestsTool($this->userId),
+            new ProposeRunEditTool($this->userId),
+            new ProposeRunDeleteTool($this->userId),
         ];
     }
 

--- a/app/Ai/Streaming/SseEventFormatter.php
+++ b/app/Ai/Streaming/SseEventFormatter.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ai\Streaming;
+
+use Laravel\Ai\Streaming\Events\StreamEvent;
+use Laravel\Ai\Streaming\Events\ToolResult;
+
+class SseEventFormatter
+{
+    /** @var list<string> */
+    private const PROPOSE_TOOLS = ['propose_run_edit', 'propose_run_delete'];
+
+    /**
+     * Convert a streamed agent event into one or two SSE `data: ...\n\n` frames.
+     *
+     * Standard events pass through unchanged (matching the SDK protocol the
+     * existing client expects). When the event is a tool result from a
+     * `propose_*` tool, an additional `pending_action` frame is emitted so the
+     * Svelte UI can render a confirm card without scraping the LLM's prose.
+     *
+     * @return list<string>
+     */
+    public function format(StreamEvent $event): array
+    {
+        $frames = ['data: '.((string) $event)."\n\n"];
+
+        if ($event instanceof ToolResult && in_array($event->toolResult->name, self::PROPOSE_TOOLS, true)) {
+            $pending = $this->extractPendingAction($event->toolResult->result);
+
+            if ($pending !== null) {
+                $frames[] = 'data: '.json_encode([
+                    'type' => 'pending_action',
+                    'id' => $pending['id'],
+                    'action_type' => $pending['type'],
+                    'run_id' => $pending['run_id'],
+                    'changes' => $pending['changes'],
+                    'summary' => $pending['summary'],
+                    'expires_at' => $pending['expires_at'],
+                ])."\n\n";
+            }
+        }
+
+        return $frames;
+    }
+
+    public function done(): string
+    {
+        return "data: [DONE]\n\n";
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function extractPendingAction(mixed $result): ?array
+    {
+        if (is_string($result)) {
+            $decoded = json_decode($result, true);
+        } elseif (is_array($result)) {
+            $decoded = $result;
+        } else {
+            return null;
+        }
+
+        if (! is_array($decoded) || ! isset($decoded['pending_action']) || ! is_array($decoded['pending_action'])) {
+            return null;
+        }
+
+        $pa = $decoded['pending_action'];
+
+        foreach (['id', 'type', 'run_id', 'changes', 'summary', 'expires_at'] as $key) {
+            if (! array_key_exists($key, $pa)) {
+                return null;
+            }
+        }
+
+        return $pa;
+    }
+}

--- a/app/Ai/Tools/ComparePeriodsTool.php
+++ b/app/Ai/Tools/ComparePeriodsTool.php
@@ -14,6 +14,11 @@ class ComparePeriodsTool implements Tool
 {
     public function __construct(private int $userId) {}
 
+    public function name(): string
+    {
+        return 'compare_periods';
+    }
+
     public function description(): Stringable|string
     {
         return 'Compare aggregated run statistics for two date ranges side-by-side. Both periods are aggregated independently and returned under `period_a` and `period_b`. Dates should be ISO date strings (YYYY-MM-DD).';

--- a/app/Ai/Tools/FetchHeartRateDataTool.php
+++ b/app/Ai/Tools/FetchHeartRateDataTool.php
@@ -14,6 +14,11 @@ class FetchHeartRateDataTool implements Tool
 {
     public function __construct(private int $userId) {}
 
+    public function name(): string
+    {
+        return 'fetch_heart_rate_data';
+    }
+
     public function description(): Stringable|string
     {
         return 'Fetch heart rate data across recent runs. Returns per-run average HR, max observed HR, and time-in-zone estimates.';

--- a/app/Ai/Tools/FetchPersonalBestsTool.php
+++ b/app/Ai/Tools/FetchPersonalBestsTool.php
@@ -14,6 +14,11 @@ class FetchPersonalBestsTool implements Tool
 {
     public function __construct(private int $userId) {}
 
+    public function name(): string
+    {
+        return 'fetch_personal_bests';
+    }
+
     public function description(): Stringable|string
     {
         return 'Fetch the user\'s personal bests at the standard race distance milestones (1k, 5k, 10k, HM, M). Each entry includes the underlying run id, the run date, the run\'s actual distance, the average pace, and a predicted finish time at the milestone distance, plus a `url` for citation. Entries are null when no eligible run exists.';

--- a/app/Ai/Tools/FetchRunDetailTool.php
+++ b/app/Ai/Tools/FetchRunDetailTool.php
@@ -14,6 +14,11 @@ class FetchRunDetailTool implements Tool
 {
     public function __construct(private int $userId) {}
 
+    public function name(): string
+    {
+        return 'fetch_run_detail';
+    }
+
     public function description(): Stringable|string
     {
         return 'Fetch a single run with its heart rate samples and pace splits. Returns the run data plus a `url` for citation, or `{ "error": ... }` if the run does not exist or belongs to another user.';

--- a/app/Ai/Tools/FetchRunStatsTool.php
+++ b/app/Ai/Tools/FetchRunStatsTool.php
@@ -14,6 +14,11 @@ class FetchRunStatsTool implements Tool
 {
     public function __construct(private int $userId) {}
 
+    public function name(): string
+    {
+        return 'fetch_run_stats';
+    }
+
     public function description(): Stringable|string
     {
         return 'Fetch aggregated run statistics for the user over a given period. Returns total distance, total time, run count, average pace, and best pace.';

--- a/app/Ai/Tools/FetchRunsTool.php
+++ b/app/Ai/Tools/FetchRunsTool.php
@@ -14,6 +14,11 @@ class FetchRunsTool implements Tool
 {
     public function __construct(private int $userId) {}
 
+    public function name(): string
+    {
+        return 'fetch_runs';
+    }
+
     public function description(): Stringable|string
     {
         return 'Fetch the user\'s runs with optional filters. Supports rolling-window (days) or absolute date range (from/to), plus min/max filters on distance, pace, and average heart rate. Returns an array of runs each containing a `url` for citation.';

--- a/app/Ai/Tools/ProposeRunDeleteTool.php
+++ b/app/Ai/Tools/ProposeRunDeleteTool.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ai\Tools;
+
+use App\Models\Run;
+use App\Services\Ai\PendingActionStore;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Stringable;
+
+class ProposeRunDeleteTool implements Tool
+{
+    public function __construct(
+        private int $userId,
+        private PendingActionStore $store = new PendingActionStore,
+    ) {}
+
+    public function name(): string
+    {
+        return 'propose_run_delete';
+    }
+
+    public function description(): Stringable|string
+    {
+        return 'Propose deleting one of the user\'s runs. This NEVER deletes directly — it returns a pending_action envelope and the UI renders a confirm card. Your text reply should be a single short sentence describing the proposal (no JSON, no UUID).';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        $runId = (int) ($request['run_id'] ?? 0);
+
+        $run = Run::query()
+            ->where('user_id', $this->userId)
+            ->find($runId);
+
+        if (! $run instanceof Run) {
+            return json_encode([
+                'error' => "Run {$runId} was not found or does not belong to the user.",
+            ]);
+        }
+
+        $summary = sprintf(
+            'Delete run on %s — %s km, %d min',
+            $run->start_time->toDateString(),
+            number_format((float) $run->distance_km, 2),
+            (int) round($run->duration_seconds / 60),
+        );
+
+        $stored = $this->store->put([
+            'type' => 'delete_run',
+            'run_id' => $run->id,
+            'user_id' => $this->userId,
+            'changes' => [],
+            'summary' => $summary,
+        ]);
+
+        return json_encode(['pending_action' => $stored]);
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'run_id' => $schema->integer()->required(),
+        ];
+    }
+}

--- a/app/Ai/Tools/ProposeRunEditTool.php
+++ b/app/Ai/Tools/ProposeRunEditTool.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ai\Tools;
+
+use App\Models\Run;
+use App\Services\Ai\PendingActionStore;
+use App\Services\Runs\UpdateRunAction;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Tools\Request;
+use Stringable;
+
+class ProposeRunEditTool implements Tool
+{
+    public function __construct(
+        private int $userId,
+        private PendingActionStore $store = new PendingActionStore,
+    ) {}
+
+    public function name(): string
+    {
+        return 'propose_run_edit';
+    }
+
+    public function description(): Stringable|string
+    {
+        return 'Propose editing one of the user\'s runs. This NEVER mutates directly — it returns a pending_action envelope and the UI renders a confirm card. Supply only the fields you want to change. Your text reply should be a single short sentence describing the proposal (no JSON, no UUID).';
+    }
+
+    public function handle(Request $request): Stringable|string
+    {
+        $runId = (int) ($request['run_id'] ?? 0);
+
+        $run = Run::query()
+            ->where('user_id', $this->userId)
+            ->find($runId);
+
+        if (! $run instanceof Run) {
+            return json_encode([
+                'error' => "Run {$runId} was not found or does not belong to the user.",
+            ]);
+        }
+
+        $arguments = $request->toArray();
+        $changes = [];
+        foreach (UpdateRunAction::EDITABLE_FIELDS as $field) {
+            if (array_key_exists($field, $arguments) && $arguments[$field] !== null) {
+                $changes[$field] = $arguments[$field];
+            }
+        }
+
+        if ($changes === []) {
+            return json_encode([
+                'error' => 'No editable fields were provided. Supply at least one of: '.implode(', ', UpdateRunAction::EDITABLE_FIELDS).'.',
+            ]);
+        }
+
+        $summary = $this->buildSummary($run, $changes);
+
+        $stored = $this->store->put([
+            'type' => 'edit_run',
+            'run_id' => $run->id,
+            'user_id' => $this->userId,
+            'changes' => $changes,
+            'summary' => $summary,
+        ]);
+
+        return json_encode(['pending_action' => $stored]);
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'run_id' => $schema->integer()->required(),
+            'start_time' => $schema->string(),
+            'end_time' => $schema->string(),
+            'distance_km' => $schema->number(),
+            'duration_seconds' => $schema->integer(),
+            'steps' => $schema->integer(),
+            'avg_heart_rate' => $schema->integer(),
+            'avg_pace_seconds_per_km' => $schema->integer(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $changes
+     */
+    private function buildSummary(Run $run, array $changes): string
+    {
+        $parts = [];
+        foreach ($changes as $field => $newValue) {
+            $current = $run->getAttribute($field);
+            $parts[] = sprintf('%s %s → %s', $field, $this->formatValue($current), $this->formatValue($newValue));
+        }
+
+        return sprintf(
+            'Edit run on %s: %s',
+            $run->start_time->toDateString(),
+            implode(', ', $parts),
+        );
+    }
+
+    private function formatValue(mixed $value): string
+    {
+        if ($value === null) {
+            return '—';
+        }
+
+        if (is_object($value) && method_exists($value, 'toDateTimeString')) {
+            return $value->toDateTimeString();
+        }
+
+        return (string) $value;
+    }
+}

--- a/app/Http/Controllers/Analysis/ChatController.php
+++ b/app/Http/Controllers/Analysis/ChatController.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Analysis;
 
 use App\Ai\Agents\RunCoachAgent;
+use App\Ai\Streaming\SseEventFormatter;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Laravel\Ai\Messages\AssistantMessage;
 use Laravel\Ai\Messages\UserMessage;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ChatController
 {
-    public function stream(Request $request): Response|JsonResponse
+    public function stream(Request $request, SseEventFormatter $formatter): Response|JsonResponse
     {
         $validated = $request->validate([
             'messages' => 'required|array|min:1',
@@ -39,7 +41,32 @@ class ChatController
         );
 
         $agent = new RunCoachAgent($request->user()->id, $history);
+        $stream = $agent->stream($latest['content']);
 
-        return $agent->stream($latest['content'])->toResponse($request);
+        return new StreamedResponse(function () use ($stream, $formatter): void {
+            foreach ($stream as $event) {
+                if (connection_aborted()) {
+                    return;
+                }
+
+                foreach ($formatter->format($event) as $frame) {
+                    echo $frame;
+                    if (ob_get_level() > 0) {
+                        ob_flush();
+                    }
+                    flush();
+                }
+            }
+
+            echo $formatter->done();
+            if (ob_get_level() > 0) {
+                ob_flush();
+            }
+            flush();
+        }, 200, [
+            'Content-Type' => 'text/event-stream',
+            'Cache-Control' => 'no-cache',
+            'X-Accel-Buffering' => 'no',
+        ]);
     }
 }

--- a/app/Http/Controllers/Analysis/ConfirmActionController.php
+++ b/app/Http/Controllers/Analysis/ConfirmActionController.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Analysis;
+
+use App\Http\Requests\Runs\UpdateRunRequest;
+use App\Http\Resources\RunResource;
+use App\Models\Run;
+use App\Services\Ai\PendingActionStore;
+use App\Services\Runs\UpdateRunAction;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+
+class ConfirmActionController
+{
+    public function __invoke(
+        Request $request,
+        string $id,
+        PendingActionStore $store,
+        UpdateRunAction $updateRun,
+    ): JsonResponse {
+        $action = $store->get($id);
+
+        if ($action === null) {
+            return response()->json([
+                'message' => 'This action has expired or is invalid.',
+            ], 404);
+        }
+
+        if (($action['user_id'] ?? null) !== $request->user()->id) {
+            abort(403);
+        }
+
+        $run = Run::query()
+            ->where('user_id', $action['user_id'])
+            ->find($action['run_id'] ?? null);
+
+        if (! $run instanceof Run) {
+            $store->forget($id);
+
+            return response()->json([
+                'message' => 'The run no longer exists.',
+            ], 404);
+        }
+
+        $result = match ($action['type'] ?? null) {
+            'delete_run' => $this->executeDelete($run),
+            'edit_run' => $this->executeEdit($run, $action['changes'] ?? [], $updateRun),
+            default => throw ValidationException::withMessages([
+                'action' => 'Unsupported pending action type.',
+            ]),
+        };
+
+        $store->forget($id);
+
+        return response()->json([
+            'status' => 'executed',
+            'result' => $result,
+        ]);
+    }
+
+    /**
+     * @return array{deleted_run_id: int}
+     */
+    private function executeDelete(Run $run): array
+    {
+        $deletedId = $run->id;
+        $run->delete();
+
+        return ['deleted_run_id' => $deletedId];
+    }
+
+    /**
+     * @param  array<string, mixed>  $changes
+     * @return array{run: RunResource}
+     */
+    private function executeEdit(Run $run, array $changes, UpdateRunAction $updateRun): array
+    {
+        Validator::make($changes, UpdateRunRequest::baseRules())->validate();
+
+        return ['run' => new RunResource($updateRun->execute($run, $changes))];
+    }
+}

--- a/app/Http/Controllers/Runs/UpdateController.php
+++ b/app/Http/Controllers/Runs/UpdateController.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Runs;
+
+use App\Http\Requests\Runs\UpdateRunRequest;
+use App\Http\Resources\RunResource;
+use App\Models\Run;
+use App\Services\Runs\UpdateRunAction;
+use Illuminate\Http\JsonResponse;
+
+class UpdateController
+{
+    public function __invoke(UpdateRunRequest $request, Run $run, UpdateRunAction $action): JsonResponse
+    {
+        $updated = $action->execute($run, $request->validated());
+
+        return response()->json([
+            'run' => new RunResource($updated),
+        ]);
+    }
+}

--- a/app/Http/Requests/Runs/UpdateRunRequest.php
+++ b/app/Http/Requests/Runs/UpdateRunRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Runs;
+
+use App\Models\Run;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRunRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $run = $this->route('run');
+
+        return $this->user() !== null
+            && $run instanceof Run
+            && $run->user_id === $this->user()->id;
+    }
+
+    /** @return array<string, array<int, mixed>> */
+    public function rules(): array
+    {
+        return self::baseRules();
+    }
+
+    /**
+     * Rule set shared with the chat-confirm endpoint so server-stored changes
+     * are revalidated before being applied to the model.
+     *
+     * @return array<string, array<int, mixed>>
+     */
+    public static function baseRules(): array
+    {
+        return [
+            'start_time' => ['sometimes', 'date', 'before_or_equal:now'],
+            'end_time' => ['sometimes', 'date', 'after:start_time'],
+            'distance_km' => ['sometimes', 'numeric', 'min:0.001'],
+            'duration_seconds' => ['sometimes', 'integer', 'min:1'],
+            'steps' => ['sometimes', 'nullable', 'integer', 'min:0'],
+            'avg_heart_rate' => ['sometimes', 'nullable', 'integer', 'min:0', 'max:300'],
+            'avg_pace_seconds_per_km' => ['sometimes', 'nullable', 'integer', 'min:0'],
+        ];
+    }
+}

--- a/app/Services/Ai/PendingActionStore.php
+++ b/app/Services/Ai/PendingActionStore.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ai;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+class PendingActionStore
+{
+    public const TTL_SECONDS = 600;
+
+    public const KEY_PREFIX = 'pending_action:';
+
+    /**
+     * Persist a pending chat-proposed action and return the stored payload,
+     * stamped with `id` and `expires_at`.
+     *
+     * @param  array{type: string, run_id: int, user_id: int, changes: array<string, mixed>, summary: string}  $payload
+     * @return array<string, mixed>
+     */
+    public function put(array $payload): array
+    {
+        $id = (string) Str::uuid();
+        $expiresAt = now()->addSeconds(self::TTL_SECONDS);
+
+        $stored = [
+            ...$payload,
+            'id' => $id,
+            'expires_at' => $expiresAt->toIso8601String(),
+        ];
+
+        Cache::put(self::KEY_PREFIX.$id, $stored, self::TTL_SECONDS);
+
+        return $stored;
+    }
+
+    /** @return array<string, mixed>|null */
+    public function get(string $id): ?array
+    {
+        $value = Cache::get(self::KEY_PREFIX.$id);
+
+        return is_array($value) ? $value : null;
+    }
+
+    public function forget(string $id): void
+    {
+        Cache::forget(self::KEY_PREFIX.$id);
+    }
+}

--- a/app/Services/Runs/UpdateRunAction.php
+++ b/app/Services/Runs/UpdateRunAction.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Runs;
+
+use App\Models\Run;
+
+class UpdateRunAction
+{
+    /** @var list<string> */
+    public const EDITABLE_FIELDS = [
+        'start_time',
+        'end_time',
+        'distance_km',
+        'duration_seconds',
+        'steps',
+        'avg_heart_rate',
+        'avg_pace_seconds_per_km',
+    ];
+
+    /**
+     * Apply the supplied changes to the run and persist.
+     *
+     * @param  array<string, mixed>  $changes
+     */
+    public function execute(Run $run, array $changes): Run
+    {
+        $allowed = array_intersect_key($changes, array_flip(self::EDITABLE_FIELDS));
+
+        $run->fill($allowed)->save();
+
+        return $run->refresh();
+    }
+}

--- a/resources/js/components/analysis/ConfirmCard.svelte
+++ b/resources/js/components/analysis/ConfirmCard.svelte
@@ -1,0 +1,108 @@
+<script lang="ts" module>
+    export type PendingActionType = 'edit_run' | 'delete_run';
+
+    export type PendingAction = {
+        id: string;
+        action_type: PendingActionType;
+        run_id: number;
+        changes: Record<string, unknown>;
+        summary: string;
+        expires_at: string;
+    };
+
+    export type ConfirmResult =
+        | { status: 'executed'; result: Record<string, unknown> }
+        | { status: 'cancelled' }
+        | { status: 'error'; message: string };
+</script>
+
+<script lang="ts">
+    import Check from 'lucide-svelte/icons/check';
+    import LoaderCircle from 'lucide-svelte/icons/loader-circle';
+    import X from 'lucide-svelte/icons/x';
+    import { Button } from '@/components/ui/button';
+
+    let { action, onResult }: { action: PendingAction; onResult: (result: ConfirmResult) => void } = $props();
+
+    let state = $state<'idle' | 'submitting' | 'done' | 'cancelled' | 'error'>('idle');
+    let errorMessage = $state<string | null>(null);
+
+    function csrfToken(): string {
+        return decodeURIComponent(document.cookie.match(/XSRF-TOKEN=([^;]+)/)?.[1] ?? '');
+    }
+
+    async function confirm(): Promise<void> {
+        state = 'submitting';
+        errorMessage = null;
+        try {
+            const response = await fetch(`/analysis/actions/${action.id}/confirm`, {
+                method: 'POST',
+                headers: {
+                    Accept: 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'X-XSRF-TOKEN': csrfToken(),
+                },
+            });
+            const body = await response.json().catch(() => ({}));
+            if (!response.ok) {
+                throw new Error(body?.message ?? `Request failed (${response.status})`);
+            }
+            state = 'done';
+            onResult({ status: 'executed', result: body.result ?? {} });
+        } catch (err) {
+            errorMessage = (err as Error).message || 'Could not run that action.';
+            state = 'error';
+            onResult({ status: 'error', message: errorMessage });
+        }
+    }
+
+    function cancel(): void {
+        state = 'cancelled';
+        onResult({ status: 'cancelled' });
+    }
+
+    const title = $derived(action.action_type === 'delete_run' ? 'Confirm delete' : 'Confirm edit');
+    const changeEntries = $derived(Object.entries(action.changes ?? {}));
+</script>
+
+<div
+    class="mt-3 rounded-xl border border-amber-300/70 bg-amber-50 p-3 text-amber-950 dark:border-amber-700/40 dark:bg-amber-950/30 dark:text-amber-100"
+    role="region"
+    aria-label={title}
+>
+    <p class="text-sm font-semibold">{title}</p>
+    <p class="mt-1 text-sm">{action.summary}</p>
+
+    {#if action.action_type === 'edit_run' && changeEntries.length > 0}
+        <ul class="mt-2 list-disc space-y-0.5 pl-5 text-xs">
+            {#each changeEntries as [field, value] (field)}
+                <li>
+                    <span class="font-medium">{field}</span>: {String(value)}
+                </li>
+            {/each}
+        </ul>
+    {/if}
+
+    {#if state === 'done'}
+        <p class="mt-3 text-sm font-medium">Done.</p>
+    {:else if state === 'cancelled'}
+        <p class="mt-3 text-sm text-muted-foreground">Cancelled.</p>
+    {:else if state === 'error'}
+        <p class="mt-3 text-sm text-destructive">{errorMessage}</p>
+    {:else}
+        <div class="mt-3 flex gap-2">
+            <Button size="sm" onclick={confirm} disabled={state === 'submitting'}>
+                {#if state === 'submitting'}
+                    <LoaderCircle class="size-4 animate-spin" />
+                {:else}
+                    <Check class="size-4" />
+                {/if}
+                Confirm
+            </Button>
+            <Button size="sm" variant="outline" onclick={cancel} disabled={state === 'submitting'}>
+                <X class="size-4" />
+                Cancel
+            </Button>
+        </div>
+    {/if}
+</div>

--- a/resources/js/pages/analysis/Index.svelte
+++ b/resources/js/pages/analysis/Index.svelte
@@ -15,6 +15,7 @@
     import { Markdown } from 'svelte-exmarkdown';
     import { gfmPlugin } from 'svelte-exmarkdown/gfm';
     import AppHead from '@/components/AppHead.svelte';
+    import ConfirmCard, { type ConfirmResult, type PendingAction } from '@/components/analysis/ConfirmCard.svelte';
     import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
     import AppLayout from '@/layouts/AppLayout.svelte';
     import type { BreadcrumbItem } from '@/types';
@@ -23,14 +24,27 @@
     type StarterPrompt = { id: string; label: string; prompt: string };
     type ToolCall = { name: string; args: Record<string, unknown> };
     type Role = 'user' | 'assistant';
-    type ChatMessage = { id: string; role: Role; content: string; toolCalls?: ToolCall[] };
+    type ConfirmStatus = 'executed' | 'cancelled' | 'error';
+    type ChatMessage = {
+        id: string;
+        role: Role;
+        content: string;
+        toolCalls?: ToolCall[];
+        pendingAction?: PendingAction;
+        confirmStatus?: ConfirmStatus;
+    };
 
     let { starterPrompts, runCount }: { starterPrompts: StarterPrompt[]; runCount: number } = $props();
 
     let messages = $state<ChatMessage[]>([]);
     let input = $state('');
     let streaming = $state(false);
-    let currentAssistant = $state<{ id: string; content: string; toolCalls: ToolCall[] } | null>(null);
+    let currentAssistant = $state<{
+        id: string;
+        content: string;
+        toolCalls: ToolCall[];
+        pendingAction?: PendingAction;
+    } | null>(null);
     let error = $state<string | null>(null);
     let isAtBottom = $state(true);
 
@@ -49,6 +63,8 @@
         fetch_run_detail: { label: 'Opening run detail', icon: FileText },
         compare_periods: { label: 'Comparing periods', icon: GitCompareArrows },
         fetch_personal_bests: { label: 'Looking up PBs', icon: Trophy },
+        propose_run_edit: { label: 'Proposing edit', icon: Wrench },
+        propose_run_delete: { label: 'Proposing delete', icon: Wrench },
     };
 
     function toolLabel(name: string): string {
@@ -207,7 +223,18 @@
                 finalize();
                 return;
             }
-            let parsed: { type?: string; delta?: string; tool_name?: string; arguments?: Record<string, unknown> };
+            let parsed: {
+                type?: string;
+                delta?: string;
+                tool_name?: string;
+                arguments?: Record<string, unknown>;
+                id?: string;
+                action_type?: 'edit_run' | 'delete_run';
+                run_id?: number;
+                changes?: Record<string, unknown>;
+                summary?: string;
+                expires_at?: string;
+            };
             try {
                 parsed = JSON.parse(payload);
             } catch {
@@ -229,12 +256,32 @@
                     ],
                 };
                 maybeAutoScroll();
+            } else if (
+                parsed.type === 'pending_action' &&
+                typeof parsed.id === 'string' &&
+                (parsed.action_type === 'edit_run' || parsed.action_type === 'delete_run')
+            ) {
+                currentAssistant = {
+                    ...currentAssistant,
+                    pendingAction: {
+                        id: parsed.id,
+                        action_type: parsed.action_type,
+                        run_id: parsed.run_id ?? 0,
+                        changes: parsed.changes ?? {},
+                        summary: parsed.summary ?? '',
+                        expires_at: parsed.expires_at ?? '',
+                    },
+                };
+                maybeAutoScroll();
             }
         }
     }
 
     function finalize(): void {
-        if (currentAssistant && (currentAssistant.content || currentAssistant.toolCalls.length)) {
+        if (
+            currentAssistant &&
+            (currentAssistant.content || currentAssistant.toolCalls.length || currentAssistant.pendingAction)
+        ) {
             messages = [
                 ...messages,
                 {
@@ -242,12 +289,17 @@
                     role: 'assistant',
                     content: currentAssistant.content,
                     toolCalls: currentAssistant.toolCalls,
+                    pendingAction: currentAssistant.pendingAction,
                 },
             ];
         }
         currentAssistant = null;
         streaming = false;
         abortController = null;
+    }
+
+    function handleConfirmResult(messageId: string, result: ConfirmResult): void {
+        messages = messages.map((m) => (m.id === messageId ? { ...m, confirmStatus: result.status } : m));
     }
 
     function stop(): void {
@@ -355,6 +407,12 @@
                                         <div class={proseChat}>
                                             <Markdown md={message.content} plugins={markdownPlugins} />
                                         </div>
+                                        {#if message.pendingAction && !message.confirmStatus}
+                                            <ConfirmCard
+                                                action={message.pendingAction}
+                                                onResult={(r) => handleConfirmResult(message.id, r)}
+                                            />
+                                        {/if}
                                     </div>
                                 </div>
                             {/if}
@@ -396,6 +454,9 @@
                                             <span class="size-1.5 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:-0.15s]"></span>
                                             <span class="size-1.5 animate-bounce rounded-full bg-muted-foreground/60"></span>
                                         </div>
+                                    {/if}
+                                    {#if currentAssistant.pendingAction}
+                                        <ConfirmCard action={currentAssistant.pendingAction} onResult={() => {}} />
                                     {/if}
                                 </div>
                             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,11 +1,13 @@
 <?php
 
 use App\Http\Controllers\Analysis\ChatController as AnalysisChatController;
+use App\Http\Controllers\Analysis\ConfirmActionController as AnalysisConfirmActionController;
 use App\Http\Controllers\Analysis\IndexController as AnalysisIndexController;
 use App\Http\Controllers\Analysis\RunSkillController;
 use App\Http\Controllers\Runs\DestroyController as RunsDestroyController;
 use App\Http\Controllers\Runs\IndexController as RunsIndexController;
 use App\Http\Controllers\Runs\ShowController as RunsShowController;
+use App\Http\Controllers\Runs\UpdateController as RunsUpdateController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use Laravel\Fortify\Features;
@@ -19,10 +21,14 @@ Route::get('/', function () {
 Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('dashboard', RunsIndexController::class)->name('dashboard');
     Route::get('runs/{run}', RunsShowController::class)->name('runs.show');
+    Route::patch('runs/{run}', RunsUpdateController::class)->name('runs.update');
     Route::delete('runs/{run}', RunsDestroyController::class)->name('runs.destroy');
 
     Route::get('analysis', AnalysisIndexController::class)->name('analysis.index');
     Route::post('analysis/chat', [AnalysisChatController::class, 'stream'])->name('analysis.chat');
+    Route::post('analysis/actions/{id}/confirm', AnalysisConfirmActionController::class)
+        ->whereUuid('id')
+        ->name('analysis.actions.confirm');
     Route::post('analysis/{skill}', RunSkillController::class)->name('analysis.run');
 });
 

--- a/tests/Feature/Ai/Tools/ProposeRunDeleteToolTest.php
+++ b/tests/Feature/Ai/Tools/ProposeRunDeleteToolTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Ai\Tools\ProposeRunDeleteTool;
+use App\Models\Run;
+use App\Models\User;
+use App\Services\Ai\PendingActionStore;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Ai\Tools\Request;
+
+beforeEach(function () {
+    Cache::flush();
+    $this->user = User::factory()->create();
+});
+
+test('exposes a snake_case tool name so the SSE formatter can match it', function () {
+    expect((new ProposeRunDeleteTool(1))->name())->toBe('propose_run_delete');
+});
+
+test('returns a pending_action envelope and stores it in cache', function () {
+    $run = Run::factory()->for($this->user)->create([
+        'distance_km' => 8.20,
+        'duration_seconds' => 2400,
+    ]);
+
+    $tool = new ProposeRunDeleteTool($this->user->id);
+    $payload = json_decode((string) $tool->handle(new Request(['run_id' => $run->id])), true);
+
+    expect($payload['pending_action']['type'])->toBe('delete_run');
+    expect($payload['pending_action']['run_id'])->toBe($run->id);
+    expect($payload['pending_action']['summary'])->toContain('8.20 km');
+    expect($payload['pending_action']['summary'])->toContain('40 min');
+    expect($payload['pending_action']['id'])->toBeString();
+
+    $cached = Cache::get('pending_action:'.$payload['pending_action']['id']);
+    expect($cached['user_id'])->toBe($this->user->id);
+    expect($cached['type'])->toBe('delete_run');
+    expect($cached['run_id'])->toBe($run->id);
+});
+
+test('does not delete the run when called', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    (new ProposeRunDeleteTool($this->user->id))
+        ->handle(new Request(['run_id' => $run->id]));
+
+    $this->assertDatabaseHas('runs', ['id' => $run->id]);
+});
+
+test('rejects a run owned by another user', function () {
+    $other = User::factory()->create();
+    $run = Run::factory()->for($other)->create();
+
+    $payload = json_decode((string) (new ProposeRunDeleteTool($this->user->id))
+        ->handle(new Request(['run_id' => $run->id])), true);
+
+    expect($payload)->toHaveKey('error');
+    expect($payload)->not->toHaveKey('pending_action');
+});
+
+test('returns an error envelope when the run does not exist', function () {
+    $payload = json_decode((string) (new ProposeRunDeleteTool($this->user->id))
+        ->handle(new Request(['run_id' => 999999])), true);
+
+    expect($payload)->toHaveKey('error');
+});
+
+test('cached entry expires after the configured TTL', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    $payload = json_decode((string) (new ProposeRunDeleteTool($this->user->id))
+        ->handle(new Request(['run_id' => $run->id])), true);
+
+    $id = $payload['pending_action']['id'];
+    expect(Cache::get('pending_action:'.$id))->not->toBeNull();
+
+    $this->travel(PendingActionStore::TTL_SECONDS + 5)->seconds();
+
+    expect(Cache::get('pending_action:'.$id))->toBeNull();
+});

--- a/tests/Feature/Ai/Tools/ProposeRunEditToolTest.php
+++ b/tests/Feature/Ai/Tools/ProposeRunEditToolTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Ai\Tools\ProposeRunEditTool;
+use App\Models\Run;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Ai\Tools\Request;
+
+beforeEach(function () {
+    Cache::flush();
+    $this->user = User::factory()->create();
+});
+
+test('exposes a snake_case tool name so the SSE formatter can match it', function () {
+    expect((new ProposeRunEditTool(1))->name())->toBe('propose_run_edit');
+});
+
+test('returns a pending_action envelope and stores only the supplied changes', function () {
+    $run = Run::factory()->for($this->user)->create([
+        'distance_km' => 8.000,
+        'avg_heart_rate' => 150,
+    ]);
+
+    $tool = new ProposeRunEditTool($this->user->id);
+    $payload = json_decode((string) $tool->handle(new Request([
+        'run_id' => $run->id,
+        'distance_km' => 8.5,
+    ])), true);
+
+    expect($payload['pending_action']['type'])->toBe('edit_run');
+    expect($payload['pending_action']['changes'])->toBe(['distance_km' => 8.5]);
+    expect($payload['pending_action']['summary'])->toContain('distance_km');
+
+    $cached = Cache::get('pending_action:'.$payload['pending_action']['id']);
+    expect($cached['changes'])->toBe(['distance_km' => 8.5]);
+    expect($cached['user_id'])->toBe($this->user->id);
+});
+
+test('does not mutate the run', function () {
+    $run = Run::factory()->for($this->user)->create(['distance_km' => 8.000]);
+
+    (new ProposeRunEditTool($this->user->id))
+        ->handle(new Request(['run_id' => $run->id, 'distance_km' => 12]));
+
+    expect((float) $run->fresh()->distance_km)->toBe(8.0);
+});
+
+test('errors when no editable fields are provided', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    $payload = json_decode((string) (new ProposeRunEditTool($this->user->id))
+        ->handle(new Request(['run_id' => $run->id])), true);
+
+    expect($payload)->toHaveKey('error');
+    expect($payload)->not->toHaveKey('pending_action');
+});
+
+test('rejects a run owned by another user', function () {
+    $other = User::factory()->create();
+    $run = Run::factory()->for($other)->create();
+
+    $payload = json_decode((string) (new ProposeRunEditTool($this->user->id))
+        ->handle(new Request(['run_id' => $run->id, 'distance_km' => 5])), true);
+
+    expect($payload)->toHaveKey('error');
+});
+
+test('ignores unknown fields and null values', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    $payload = json_decode((string) (new ProposeRunEditTool($this->user->id))
+        ->handle(new Request([
+            'run_id' => $run->id,
+            'distance_km' => 10,
+            'steps' => null,
+            'nonsense' => 'ignored',
+        ])), true);
+
+    expect($payload['pending_action']['changes'])->toBe(['distance_km' => 10]);
+});

--- a/tests/Feature/Analysis/ChatTest.php
+++ b/tests/Feature/Analysis/ChatTest.php
@@ -9,6 +9,8 @@ use App\Ai\Tools\FetchPersonalBestsTool;
 use App\Ai\Tools\FetchRunDetailTool;
 use App\Ai\Tools\FetchRunStatsTool;
 use App\Ai\Tools\FetchRunsTool;
+use App\Ai\Tools\ProposeRunDeleteTool;
+use App\Ai\Tools\ProposeRunEditTool;
 use App\Models\Run;
 use App\Models\User;
 
@@ -131,7 +133,7 @@ test('last message must be from the user', function () {
         ->assertJsonValidationErrors(['messages']);
 });
 
-test('agent wires up all six read tools so tool calls can stream as separate events', function () {
+test('agent wires up all read + propose tools so tool calls can stream as separate events', function () {
     $tools = collect((new RunCoachAgent(1))->tools())->map(fn ($tool) => $tool::class)->all();
 
     expect($tools)->toEqualCanonicalizing([
@@ -141,6 +143,8 @@ test('agent wires up all six read tools so tool calls can stream as separate eve
         FetchRunDetailTool::class,
         ComparePeriodsTool::class,
         FetchPersonalBestsTool::class,
+        ProposeRunEditTool::class,
+        ProposeRunDeleteTool::class,
     ]);
 });
 
@@ -149,4 +153,12 @@ test('system prompt instructs the model to cite runs by url', function () {
 
     expect($instructions)->toContain('url')
         ->and($instructions)->toContain('Citation');
+});
+
+test('system prompt includes the propose-tool confirmation rule', function () {
+    $instructions = (string) (new RunCoachAgent(1))->instructions();
+
+    expect($instructions)->toContain('propose_')
+        ->and($instructions)->toContain('confirm')
+        ->and($instructions)->toContain('Confirmation rule');
 });

--- a/tests/Feature/Analysis/ConfirmActionTest.php
+++ b/tests/Feature/Analysis/ConfirmActionTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Run;
+use App\Models\User;
+use App\Services\Ai\PendingActionStore;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    Cache::flush();
+    $this->user = User::factory()->create();
+    $this->store = new PendingActionStore;
+});
+
+test('returns 404 when the pending action does not exist', function () {
+    $this->actingAs($this->user)
+        ->postJson('/analysis/actions/'.Str::uuid().'/confirm')
+        ->assertNotFound()
+        ->assertJsonPath('message', 'This action has expired or is invalid.');
+});
+
+test('returns 403 when the action belongs to a different user', function () {
+    $other = User::factory()->create();
+    $run = Run::factory()->for($other)->create();
+
+    $stored = $this->store->put([
+        'type' => 'delete_run',
+        'run_id' => $run->id,
+        'user_id' => $other->id,
+        'changes' => [],
+        'summary' => 'Delete run',
+    ]);
+
+    $this->actingAs($this->user)
+        ->postJson("/analysis/actions/{$stored['id']}/confirm")
+        ->assertForbidden();
+});
+
+test('confirms a delete and clears the cache entry', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    $stored = $this->store->put([
+        'type' => 'delete_run',
+        'run_id' => $run->id,
+        'user_id' => $this->user->id,
+        'changes' => [],
+        'summary' => 'Delete run',
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->postJson("/analysis/actions/{$stored['id']}/confirm");
+
+    $response->assertOk()
+        ->assertJsonPath('status', 'executed')
+        ->assertJsonPath('result.deleted_run_id', $run->id);
+
+    $this->assertDatabaseMissing('runs', ['id' => $run->id]);
+    expect(Cache::get('pending_action:'.$stored['id']))->toBeNull();
+});
+
+test('a confirm token can only be used once', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    $stored = $this->store->put([
+        'type' => 'delete_run',
+        'run_id' => $run->id,
+        'user_id' => $this->user->id,
+        'changes' => [],
+        'summary' => 'Delete run',
+    ]);
+
+    $this->actingAs($this->user)
+        ->postJson("/analysis/actions/{$stored['id']}/confirm")
+        ->assertOk();
+
+    $this->actingAs($this->user)
+        ->postJson("/analysis/actions/{$stored['id']}/confirm")
+        ->assertNotFound();
+});
+
+test('confirms an edit and applies only the stored changes', function () {
+    $run = Run::factory()->for($this->user)->create([
+        'distance_km' => 5.000,
+        'duration_seconds' => 1500,
+        'avg_heart_rate' => 145,
+    ]);
+
+    $stored = $this->store->put([
+        'type' => 'edit_run',
+        'run_id' => $run->id,
+        'user_id' => $this->user->id,
+        'changes' => ['distance_km' => 6.5],
+        'summary' => 'Edit run',
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->postJson("/analysis/actions/{$stored['id']}/confirm");
+
+    $response->assertOk()
+        ->assertJsonPath('status', 'executed')
+        ->assertJsonPath('result.run.id', $run->id)
+        ->assertJsonPath('result.run.distance_km', 6.5);
+
+    $run->refresh();
+    expect((float) $run->distance_km)->toBe(6.5);
+    expect($run->duration_seconds)->toBe(1500);
+    expect($run->avg_heart_rate)->toBe(145);
+
+    expect(Cache::get('pending_action:'.$stored['id']))->toBeNull();
+});
+
+test('rejects an edit whose stored changes fail validation', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    $stored = $this->store->put([
+        'type' => 'edit_run',
+        'run_id' => $run->id,
+        'user_id' => $this->user->id,
+        'changes' => ['distance_km' => -1],
+        'summary' => 'Bad edit',
+    ]);
+
+    $this->actingAs($this->user)
+        ->postJson("/analysis/actions/{$stored['id']}/confirm")
+        ->assertUnprocessable();
+});
+
+test('returns 404 and clears the cache if the run has been deleted out-of-band', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    $stored = $this->store->put([
+        'type' => 'delete_run',
+        'run_id' => $run->id,
+        'user_id' => $this->user->id,
+        'changes' => [],
+        'summary' => 'Delete run',
+    ]);
+
+    $run->delete();
+
+    $this->actingAs($this->user)
+        ->postJson("/analysis/actions/{$stored['id']}/confirm")
+        ->assertNotFound();
+
+    expect(Cache::get('pending_action:'.$stored['id']))->toBeNull();
+});
+
+test('rejects an action with an unknown type', function () {
+    Cache::put('pending_action:bogus', [
+        'id' => 'bogus',
+        'type' => 'who_knows',
+        'run_id' => 0,
+        'user_id' => $this->user->id,
+        'changes' => [],
+        'summary' => '',
+        'expires_at' => now()->addMinutes(10)->toIso8601String(),
+    ], 600);
+
+    // Need a run that exists so we get past the run lookup branch.
+    $run = Run::factory()->for($this->user)->create();
+    Cache::put('pending_action:bogus2', [
+        'id' => 'bogus2',
+        'type' => 'who_knows',
+        'run_id' => $run->id,
+        'user_id' => $this->user->id,
+        'changes' => [],
+        'summary' => '',
+        'expires_at' => now()->addMinutes(10)->toIso8601String(),
+    ], 600);
+
+    // Route requires a UUID so we can't hit `/bogus2/confirm` directly; assert
+    // the underlying controller throws when type is unsupported by calling it
+    // via a real UUID-stored action.
+    $stored = $this->store->put([
+        'type' => 'wat',
+        'run_id' => $run->id,
+        'user_id' => $this->user->id,
+        'changes' => [],
+        'summary' => '',
+    ]);
+
+    $this->actingAs($this->user)
+        ->postJson("/analysis/actions/{$stored['id']}/confirm")
+        ->assertUnprocessable();
+});
+
+test('requires authentication', function () {
+    $this->postJson('/analysis/actions/'.Str::uuid().'/confirm')
+        ->assertUnauthorized();
+});

--- a/tests/Feature/Runs/UpdateTest.php
+++ b/tests/Feature/Runs/UpdateTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Run;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+test('unauthenticated user is redirected', function () {
+    $run = Run::factory()->create();
+
+    $this->patchJson("/runs/{$run->id}", ['distance_km' => 5])
+        ->assertUnauthorized();
+});
+
+test('user cannot update another users run', function () {
+    $other = User::factory()->create();
+    $run = Run::factory()->for($other)->create();
+
+    $this->actingAs($this->user)
+        ->patchJson("/runs/{$run->id}", ['distance_km' => 5])
+        ->assertForbidden();
+});
+
+test('partial update only touches the supplied field', function () {
+    $run = Run::factory()->for($this->user)->create([
+        'distance_km' => 5.000,
+        'duration_seconds' => 1800,
+        'avg_heart_rate' => 150,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->patchJson("/runs/{$run->id}", ['distance_km' => 8.5]);
+
+    $response->assertOk();
+    $run->refresh();
+
+    expect((float) $run->distance_km)->toBe(8.5);
+    expect($run->duration_seconds)->toBe(1800);
+    expect($run->avg_heart_rate)->toBe(150);
+});
+
+test('full update applies every editable field', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    $changes = [
+        'start_time' => '2026-05-01T09:00:00+00:00',
+        'end_time' => '2026-05-01T09:45:00+00:00',
+        'distance_km' => 9.5,
+        'duration_seconds' => 2700,
+        'steps' => 9100,
+        'avg_heart_rate' => 158,
+        'avg_pace_seconds_per_km' => 284,
+    ];
+
+    $response = $this->actingAs($this->user)->patchJson("/runs/{$run->id}", $changes);
+
+    $response->assertOk();
+    $run->refresh();
+
+    expect((float) $run->distance_km)->toBe(9.5);
+    expect($run->duration_seconds)->toBe(2700);
+    expect($run->steps)->toBe(9100);
+    expect($run->avg_heart_rate)->toBe(158);
+    expect($run->avg_pace_seconds_per_km)->toBe(284);
+});
+
+test('rejects an end_time before start_time', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    $this->actingAs($this->user)
+        ->patchJson("/runs/{$run->id}", [
+            'start_time' => '2026-05-01T09:00:00+00:00',
+            'end_time' => '2026-05-01T08:00:00+00:00',
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['end_time']);
+});
+
+test('rejects negative or zero distances', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    $this->actingAs($this->user)
+        ->patchJson("/runs/{$run->id}", ['distance_km' => 0])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['distance_km']);
+});
+
+test('returns the updated run wrapped in a run key', function () {
+    $run = Run::factory()->for($this->user)->create();
+
+    $response = $this->actingAs($this->user)
+        ->patchJson("/runs/{$run->id}", ['distance_km' => 6.25]);
+
+    $response->assertOk();
+    $response->assertJsonPath('run.id', $run->id);
+    $response->assertJsonPath('run.distance_km', 6.25);
+});

--- a/tests/Unit/Ai/Streaming/SseEventFormatterTest.php
+++ b/tests/Unit/Ai/Streaming/SseEventFormatterTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Ai\Streaming\SseEventFormatter;
+use Laravel\Ai\Responses\Data;
+use Laravel\Ai\Streaming\Events\TextDelta;
+use Laravel\Ai\Streaming\Events\ToolCall;
+use Laravel\Ai\Streaming\Events\ToolResult;
+
+function makeToolResult(string $name, mixed $result): ToolResult
+{
+    return new ToolResult(
+        id: 'evt-1',
+        toolResult: new Data\ToolResult(
+            id: 'tool-1',
+            name: $name,
+            arguments: [],
+            result: $result,
+        ),
+        successful: true,
+        error: null,
+        timestamp: 0,
+    );
+}
+
+test('text deltas pass through as a single SSE frame', function () {
+    $event = new TextDelta(id: 'evt', messageId: 'm1', delta: 'hello', timestamp: 0);
+
+    $frames = (new SseEventFormatter)->format($event);
+
+    expect($frames)->toHaveCount(1);
+    expect($frames[0])->toStartWith('data: ');
+    expect($frames[0])->toEndWith("\n\n");
+    expect($frames[0])->toContain('"type":"text_delta"');
+    expect($frames[0])->toContain('"delta":"hello"');
+});
+
+test('tool calls pass through as a single SSE frame', function () {
+    $event = new ToolCall(
+        id: 'evt',
+        toolCall: new Data\ToolCall(id: 'tool-1', name: 'fetch_runs', arguments: ['days' => 7]),
+        timestamp: 0,
+    );
+
+    $frames = (new SseEventFormatter)->format($event);
+
+    expect($frames)->toHaveCount(1);
+    expect($frames[0])->toContain('"type":"tool_call"');
+    expect($frames[0])->toContain('"tool_name":"fetch_runs"');
+});
+
+test('tool results from read-only tools pass through as a single frame', function () {
+    $event = makeToolResult('fetch_runs', json_encode([['id' => 1]]));
+
+    $frames = (new SseEventFormatter)->format($event);
+
+    expect($frames)->toHaveCount(1);
+    expect($frames[0])->toContain('"type":"tool_result"');
+});
+
+test('propose_run_delete results emit an additional pending_action frame', function () {
+    $envelope = [
+        'pending_action' => [
+            'id' => 'abc-uuid',
+            'type' => 'delete_run',
+            'run_id' => 42,
+            'changes' => [],
+            'summary' => 'Delete run on 2026-05-20 — 8.20 km, 40 min',
+            'expires_at' => '2026-05-23T12:00:00+00:00',
+        ],
+    ];
+
+    $event = makeToolResult('propose_run_delete', json_encode($envelope));
+
+    $frames = (new SseEventFormatter)->format($event);
+
+    expect($frames)->toHaveCount(2);
+    expect($frames[0])->toContain('"type":"tool_result"');
+
+    $payload = json_decode(trim(substr($frames[1], strlen('data: '))), true);
+    expect($payload['type'])->toBe('pending_action');
+    expect($payload['id'])->toBe('abc-uuid');
+    expect($payload['action_type'])->toBe('delete_run');
+    expect($payload['run_id'])->toBe(42);
+    expect($payload['summary'])->toContain('8.20 km');
+});
+
+test('propose_run_edit results emit a pending_action frame with the changes', function () {
+    $envelope = [
+        'pending_action' => [
+            'id' => 'edit-uuid',
+            'type' => 'edit_run',
+            'run_id' => 7,
+            'changes' => ['distance_km' => 8.5],
+            'summary' => 'Edit run',
+            'expires_at' => '2026-05-23T12:00:00+00:00',
+        ],
+    ];
+
+    $frames = (new SseEventFormatter)->format(makeToolResult('propose_run_edit', json_encode($envelope)));
+
+    $payload = json_decode(trim(substr($frames[1], strlen('data: '))), true);
+    expect($payload['action_type'])->toBe('edit_run');
+    expect($payload['changes'])->toBe(['distance_km' => 8.5]);
+});
+
+test('a propose tool result with malformed JSON does not crash', function () {
+    $frames = (new SseEventFormatter)->format(makeToolResult('propose_run_delete', '{not json'));
+
+    expect($frames)->toHaveCount(1);
+});
+
+test('a propose tool result missing the pending_action key emits only the original frame', function () {
+    $frames = (new SseEventFormatter)->format(makeToolResult('propose_run_delete', json_encode(['error' => 'no run'])));
+
+    expect($frames)->toHaveCount(1);
+});
+
+test('done returns the SSE done sentinel', function () {
+    expect((new SseEventFormatter)->done())->toBe("data: [DONE]\n\n");
+});


### PR DESCRIPTION
Closes #26.

## Summary

- AI coach can now propose mutations via two new tools (`propose_run_edit`, `propose_run_delete`) that never mutate directly — they persist a pending action in `Cache::` (10-min TTL, keyed by UUID, scoped to `user_id`) and return a `pending_action` envelope.
- A new SSE event type `pending_action` is emitted from the chat stream when a propose tool result flows through. The Svelte chat page renders an inline `ConfirmCard` with Confirm / Cancel buttons.
- `POST /analysis/actions/{id}/confirm` validates the stored payload, executes the action (delete the run, or apply edit via the shared `UpdateRunAction` service after revalidation against `UpdateRunRequest::baseRules()`), and clears the cache entry so tokens are single-use.
- Added `PATCH /runs/{run}` (`UpdateController` + `UpdateRunRequest`) backed by `UpdateRunAction`, shared with the confirm endpoint.
- All eight chat tools now expose a snake_case `name()` (matches the system prompt and Svelte `toolMeta`, so tool chips render the friendly labels and icons).

## Test plan

- [x] `php artisan test --compact` (183 passed, 741 assertions)
- [x] `vendor/bin/pint --dirty --format agent`
- [x] `npm run build`
- [ ] Manual smoke: ask the chat to delete most recent run → confirm card appears → Confirm POSTs to `/analysis/actions/{uuid}/confirm` → run is removed from `/dashboard`
- [ ] Manual smoke: ask the chat to change a run's distance → confirm card shows the proposed change → Confirm updates the run
- [ ] Manual smoke: a stale confirm card returns 404 after 10 minutes
- [ ] Manual smoke: a second user cannot confirm another user's token (403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)