### PR TITLE
fix: pin chat composer to viewport

### DIFF
--- a/resources/js/pages/analysis/Index.svelte
+++ b/resources/js/pages/analysis/Index.svelte
@@ -329,7 +329,7 @@
 <AppHead title="AI Coach" />
 
 <AppLayout {breadcrumbs}>
-    <div class="flex min-h-0 flex-1 flex-col">
+    <div class="flex h-[calc(100svh-4rem)] min-h-0 flex-col">
         <div
             bind:this={scrollContainer}
             onscroll={onScroll}


### PR DESCRIPTION
Closes #34.

## Summary
- `resources/js/pages/analysis/Index.svelte` outer chat shell was `flex min-h-0 flex-1 flex-col` — flex-1 inside a `min-h-svh` provider lets the wrapper grow with content, so the document body scrolled instead of the inner message list, and the `sticky bottom-0` composer drifted off-screen.
- Swapped to `flex h-[calc(100svh-4rem)] min-h-0 flex-col` — pins the chat shell to the viewport minus the `AppSidebarHeader` (h-16 / 4rem). Inner `flex-1 overflow-y-auto` on the message list now engages, and the composer stays pinned. `100svh` (small viewport height) avoids the composer jittering when mobile browser chrome shows/hides.
- Page-scoped change — no edits to `SidebarProvider`, `SidebarInset`, `AppShell`, or any other layout primitive, so other pages are unaffected.

## Test plan
- [x] `npm run build` — clean.
- [x] `php artisan test --compact` — 173 passed (sanity; no PHP touched).
- [ ] **Manual visual check needed** (I can't drive the browser): on `/analysis`, send enough messages to exceed one screen.
  - Message list scrolls internally; page body does not scroll.
  - Composer stays pinned at the bottom of the viewport.
  - "Jump to latest" floating button still appears and works.
  - Auto-scroll-to-bottom on new message still works.
- [ ] Spot-check `/dashboard`, a run detail page, `/settings/profile` still scroll normally (they don't share the change, so should be unaffected).

## Known trade-off
When the sidebar is collapsed to icon-only mode, `AppSidebarHeader` shrinks from `h-16` to `h-12`, leaving a 1rem gap below the composer. Acceptable; can address with a CSS conditional later if it bugs in real use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)